### PR TITLE
remove not required gpg key name

### DIFF
--- a/action-run.sh
+++ b/action-run.sh
@@ -25,6 +25,5 @@ docker run --rm \
         -e ENV \
         -e GPG_PRIVATE_KEY_BASE64 \
         -e GPG_PASSPHRASE \
-        -e GPG_KEY_NAME \
         -e GPG_KEY_RING=/home/gha/keyring.gpg \
         newrelic/infrastructure-publish-action

--- a/action.yml
+++ b/action.yml
@@ -34,9 +34,6 @@ inputs:
   gpg_private_key_base64:
     description: Encoded gpg key
     required: true
-  gpg_key_name:
-    description: Name of gpg key
-    required: true
 runs:
   using: "composite"
   steps:
@@ -54,4 +51,3 @@ runs:
         ENV: ${{ inputs.env }}
         SCHEMA: ${{ inputs.schema }}
         SCHEMA_URL: ${{ inputs.schema_url }}
-        GPG_KEY_NAME: ${{ inputs.gpg_key_name }}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -66,7 +66,6 @@ type config struct {
 	aptlyFolder          string
 	uploadSchemaFilePath string
 	gpgPassphrase        string
-	gpgKeyName           string
 	gpgKeyRing           string
 }
 
@@ -145,7 +144,6 @@ func loadConfig() config {
 		aptlyFolder:          aptlyF,
 		uploadSchemaFilePath: viper.GetString("upload_schema_file_path"),
 		gpgPassphrase:        viper.GetString("gpg_passphrase"),
-		gpgKeyName:           viper.GetString("gpg_key_name"),
 		gpgKeyRing:           viper.GetString("gpg_key_ring"),
 	}
 }
@@ -376,7 +374,7 @@ func uploadApt(conf config, srcTemplate string, upload Upload, arch string) (err
 		l.Printf("[✔] Added succecfully package into deb repo for %s/%s", osVersion, arch)
 
 		l.Printf("[ ] Publish deb repo for %s/%s", osVersion, arch)
-		if err = execLogOutput(l, "aptly", "publish", "repo", "-keyring", conf.gpgKeyRing, "-gpg-key", conf.gpgKeyName, "-passphrase", conf.gpgPassphrase, "-batch", osVersion); err != nil {
+		if err = execLogOutput(l, "aptly", "publish", "repo", "-keyring", conf.gpgKeyRing, "-passphrase", conf.gpgPassphrase, "-batch", osVersion); err != nil {
 			return err
 		}
 		l.Printf("[✔] Published succesfully deb repo for %s/%s", osVersion, arch)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -21,9 +21,7 @@ endif
 ifndef GPG_PASSPHRASE
 	$(error GPG_PASSPHRASE is undefined)
 endif
-ifndef GPG_KEY_NAME
-	$(error GPG_KEY_NAME is undefined)
-endif
+
 
 prepare-schema: check-env
 	@echo "prepare schema file for: ${SCHEMA}"


### PR DESCRIPTION
GPG key name is not really required. We only import one key to the keyring and so this one key will be used with aptly.
Removing the key name removes another secret that we have to maintain and simplifies things a bit.