### PR TITLE
feat lock disable ttl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,7 @@ jobs:
         run: make validate
 
       - name: Running unit tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: make test

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,15 @@ inputs:
   aws_s3_bucket_name:
     description: Name of the S3 bucket
     required: true
+  aws_s3lock_bucket_name:
+    description: Name of the S3 bucket for lockfiles
+    required: true
+  aws_role_arn:
+    description: ARN for the IAM role to be used for fetching AWS STS credentials.
+    required: true
+  aws_region:
+    description: AWS region for the buckets.
+    required: true
   repo_name:
     description: Combination of organization and repository (i.e. newrelic/nri-redis)
     required: true
@@ -18,6 +27,9 @@ inputs:
     required: true
   tag:
     description: Tag pointing to the release
+    required: true
+  run_id:
+    description: Action run identifier. To be provisioned from env-var `GITHUB_RUN_ID`.
     required: true
   schema:
     description: Name of the schema describing the packages to be published (i.e. infra-agent, ohi, nrjmx, custom - requires schemaUrl)

--- a/publisher/lock/s3_lock.go
+++ b/publisher/lock/s3_lock.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultTTL = 1 * time.Hour
+	defaultTTL = 1000 * time.Hour // disable to manage leftover lockfiles manually for now
 )
 
 // We should parametrise these:


### PR DESCRIPTION
Disable to manage leftover lockfiles manually for now, people want to use leftovers as smoke signal of potentially corrupted repos.