### PR TITLE
feat(lock): add run-id to owner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,7 @@ jobs:
         run: make validate
 
       - name: Running unit tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: make test

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,15 @@ inputs:
   aws_s3_bucket_name:
     description: Name of the S3 bucket
     required: true
+  aws_s3lock_bucket_name:
+    description: Name of the S3 bucket for lockfiles
+    required: true
+  aws_role_arn:
+    description: ARN for the IAM role to be used for fetching AWS STS credentials.
+    required: true
+  aws_region:
+    description: AWS region for the buckets.
+    required: true
   repo_name:
     description: Combination of organization and repository (i.e. newrelic/nri-redis)
     required: true
@@ -18,6 +27,9 @@ inputs:
     required: true
   tag:
     description: Tag pointing to the release
+    required: true
+  run_id:
+    description: Action run identifier. To be provisioned from env-var `GITHUB_RUN_ID`.
     required: true
   schema:
     description: Name of the schema describing the packages to be published (i.e. infra-agent, ohi, nrjmx, custom - requires schemaUrl)

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -78,12 +78,7 @@ type config struct {
 }
 
 func (c *config) owner() string {
-	runIDSuffix := ""
-	if c.runID != "" {
-		runIDSuffix = fmt.Sprintf("_%s", c.runID)
-	}
-
-	return fmt.Sprintf("%s_%s%s", c.appName, c.tag, runIDSuffix)
+	return fmt.Sprintf("%s_%s_%s", c.appName, c.tag, c.runID)
 }
 
 type uploadArtifactSchema struct {
@@ -114,6 +109,9 @@ func main() {
 	}
 	if conf.awsRegion == "" {
 		l.Fatal("missing 'aws_region' value")
+	}
+	if conf.runID == "" {
+		l.Fatal("missing 'run_id' value")
 	}
 
 	// fail fast when lacking required AWS credentials

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -71,7 +71,7 @@ type config struct {
 	gpgPassphrase        string
 	gpgKeyName           string
 	gpgKeyRing           string
-	awsBucket            string
+	awsLockBucket        string
 	lockGroup            string
 	awsRegion            string
 	awsRoleARN           string
@@ -101,8 +101,8 @@ func main() {
 	l.Println(fmt.Sprintf("config: %v", conf))
 
 	// config validation
-	if conf.awsBucket == "" {
-		l.Fatal("missing 'aws_s3_bucket_name' value")
+	if conf.awsLockBucket == "" {
+		l.Fatal("missing 'aws_s3_lock_bucket_name' value")
 	}
 	if conf.awsRoleARN == "" {
 		l.Fatal("missing 'aws_role_arn' value")
@@ -115,7 +115,7 @@ func main() {
 	}
 
 	// fail fast when lacking required AWS credentials
-	bucketLock, err := lock.NewS3(conf.awsBucket, conf.awsRoleARN, conf.awsRegion, conf.lockGroup, conf.owner())
+	bucketLock, err := lock.NewS3(conf.awsLockBucket, conf.awsRoleARN, conf.awsRegion, conf.lockGroup, conf.owner())
 	if err != nil {
 		l.Fatal("cannot create lock: " + err.Error())
 	}
@@ -158,6 +158,7 @@ func loadConfig() config {
 	viper.BindEnv("gpg_key_name")
 	viper.BindEnv("gpg_key_ring")
 	viper.BindEnv("aws_s3_bucket_name")
+	viper.BindEnv("aws_s3_lock_bucket_name")
 	viper.BindEnv("aws_role_arn")
 	viper.BindEnv("aws_region")
 
@@ -186,7 +187,7 @@ func loadConfig() config {
 		gpgKeyName:           viper.GetString("gpg_key_name"),
 		gpgKeyRing:           viper.GetString("gpg_key_ring"),
 		lockGroup:            lockGroup,
-		awsBucket:            viper.GetString("aws_s3_bucket_name"),
+		awsLockBucket:        viper.GetString("aws_s3_lock_bucket_name"),
 		awsRoleARN:           viper.GetString("aws_role_arn"),
 		awsRegion:            viper.GetString("aws_region"),
 	}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -62,6 +62,7 @@ type config struct {
 	repoName             string
 	appName              string
 	tag                  string
+	runID                string
 	version              string
 	artifactsDestFolder  string
 	artifactsSrcFolder   string
@@ -77,7 +78,12 @@ type config struct {
 }
 
 func (c *config) owner() string {
-	return fmt.Sprintf("%s_%s", c.appName, c.tag)
+	runIDSuffix := ""
+	if c.runID != "" {
+		runIDSuffix = fmt.Sprintf("_%s", c.runID)
+	}
+
+	return fmt.Sprintf("%s_%s%s", c.appName, c.tag, runIDSuffix)
 }
 
 type uploadArtifactSchema struct {
@@ -144,6 +150,7 @@ func loadConfig() config {
 	viper.BindEnv("repo_name")
 	viper.BindEnv("app_name")
 	viper.BindEnv("tag")
+	viper.BindEnv("run_id")
 	viper.BindEnv("artifacts_dest_folder")
 	viper.BindEnv("artifacts_src_folder")
 	viper.BindEnv("aptly_folder")
@@ -171,6 +178,7 @@ func loadConfig() config {
 		repoName:             viper.GetString("repo_name"),
 		appName:              viper.GetString("app_name"),
 		tag:                  viper.GetString("tag"),
+		runID:                viper.GetString("run_id"),
 		version:              strings.Replace(viper.GetString("tag"), "v", "", -1),
 		artifactsDestFolder:  viper.GetString("artifacts_dest_folder"),
 		artifactsSrcFolder:   viper.GetString("artifacts_src_folder"),


### PR DESCRIPTION
Add run ID, to owner data, so different runs won't clash and triggering actor could be identified.

This value could be provided from GHA `GITHUB_RUN_ID` env-var https://docs.github.com/en/actions/reference/environment-variables