### PR TITLE
Create missing folders in the repo

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -657,6 +657,7 @@ func ensurePath(path string) error {
 			return err
 		}
 	}
+	return nil
 }
 
 func replacePlaceholders(template, repoName, appName, arch, tag, version, destPrefix, osVersion string) (str string) {

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -631,7 +631,7 @@ func copyFile(srcPath string, destPath string, overwrite bool) (err error) {
 	
 	l.Println("[ ] Copy " + srcPath + " into " + destPath)
 	
-	if err = execLogOutput(l, "cp", "-f", srcPath, filePath); err != nil {
+	if err = execLogOutput(l, "cp", "-f", srcPath, destPath); err != nil {
 		return err
 	}
 

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -651,7 +651,7 @@ func copyFile(srcPath string, destPath string) (err error) {
 }
 
 func ensurePath(path string) error {
-	dir, file := filepath.Split(path)
+	dir, _ := filepath.Split(path)
 	if dir != "" {
 		if err := execLogOutput(l, "mkdir", "-p", dir); err != nil {
 			return err

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -653,7 +653,7 @@ func copyFile(srcPath string, destPath string) (err error) {
 func ensurePath(path string) error {
 	dir, file := filepath.Split(path)
 	if dir != "" {
-		if err = execLogOutput(l, "mkdir", "-p", dir); err != nil {
+		if err := execLogOutput(l, "mkdir", "-p", dir); err != nil {
 			return err
 		}
 	}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -363,7 +363,7 @@ func uploadRpm(conf config, srcTemplate string, upload Upload, arch string) (err
 
 		if _, err = os.Stat(repomd); os.IsNotExist(err) {
 
-			l.Printf("[ ] Didn't fine repo for %s, run repo init command", repoPath)
+			l.Printf("[ ] Didn't find repo for %s, run repo init command", repoPath)
 
 			if err := execLogOutput(l, "createrepo", repoPath, "-o", os.TempDir()); err != nil {
 				return err
@@ -461,11 +461,9 @@ func uploadApt(conf config, srcTemplate string, upload Upload, arch string) (err
 		}
 		l.Printf("[✔] Published succesfully deb repo for %s/%s", osVersion, arch)
 
-		// Copying the binary
-		//if err = copyFile(srcPath, filePath); err != nil {
-		//	return err
-		//}
-		// copy from temp repodata to repo repodata
+		// make sure the destination folder exists (it should, but new repos might not)
+		ensurePath(filePath)
+		// copy debian package to destination repo folder
 		if err = execLogOutput(l, "cp", "-f", srcPath, filePath); err != nil {
 			return err
 		}
@@ -650,6 +648,15 @@ func copyFile(srcPath string, destPath string) (err error) {
 
 	l.Println("[✔] Copy " + srcPath + " into " + destPath)
 	return nil
+}
+
+func ensurePath(path string) error {
+	dir, file := filepath.Split(path)
+	if dir != "" {
+		if err = execLogOutput(l, "mkdir", "-p", dir); err != nil {
+			return err
+		}
+	}
 }
 
 func replacePlaceholders(template, repoName, appName, arch, tag, version, destPrefix, osVersion string) (str string) {

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -374,9 +374,11 @@ func uploadRpm(conf config, srcTemplate string, upload Upload, arch string) (err
 			_ = os.Remove(signaturePath)
 		}
 
-		// "cache" the repodata so it doesnt have to process all again
-		if err = execLogOutput(l, "cp", "-rf", repoPath+"/repodata/", os.TempDir()+"/repodata/"); err != nil {
-			return err
+		// if repodata exists, "cache" it so it doesnt have to process all again
+		if _, err = os.Stat(repoPath+"/repodata/"); err == nil {
+			if err = execLogOutput(l, "cp", "-rf", repoPath+"/repodata/", os.TempDir()+"/repodata/"); err != nil {
+				return err
+			}
 		}
 
 		if err = execLogOutput(l, "createrepo", "--update", "-s", "sha", repoPath, "-o", os.TempDir()); err != nil {

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -356,7 +356,7 @@ func uploadRpm(conf config, srcTemplate string, upload Upload, arch string) (err
 		repomd := path.Join(repoPath, repodataRpmPath)
 		signaturePath := path.Join(repoPath, signatureRpmPath)
 
-		err = copyFile(srcPath, filePath, false)
+		err = copyFile(srcPath, filePath, true)
 		if err != nil {
 			return err
 		}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -643,7 +643,7 @@ func ensurePath(path string) error {
 	dir, _ := filepath.Split(path)
 	if dir != "" {
 		// is dir and dir already exists, skip creating it
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
 			return nil
 		}
 


### PR DESCRIPTION
Because we are using "cp" to copy files, repos (folders) that don't exist make the process fail