### PR TITLE
Reduce output from wget, curl and unzip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG AWS_S3_MOUNT_DIRECTORY=/mnt/s3
 
 # Tools
 # validate s3fs-fuse with the sec team
-RUN apt-get update && apt-get install -y \
+RUN apt-get -qq update && apt-get install -y \
     make \
     curl \
     gnupg2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG AWS_S3_MOUNT_DIRECTORY=/mnt/s3
 
 # Tools
 # validate s3fs-fuse with the sec team
-RUN apt-get -qq update && apt-get install -y \
+RUN apt-get -qq update && apt-get -qq install -y \
     make \
     curl \
     gnupg2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,16 @@ RUN apt-get update && apt-get install -y \
 
 # Sadly installing aptly with apt lead you to a old version not supporting gpg2
 WORKDIR /tmp
-RUN wget https://github.com/aptly-dev/aptly/releases/download/v1.4.0/aptly_1.4.0_linux_amd64.tar.gz
+RUN wget -q https://github.com/aptly-dev/aptly/releases/download/v1.4.0/aptly_1.4.0_linux_amd64.tar.gz
 RUN tar xzf aptly_1.4.0_linux_amd64.tar.gz
 RUN mv ./aptly_1.4.0_linux_amd64/aptly /usr/bin/aptly
 
 
-RUN wget https://github.com/kahing/goofys/releases/download/v0.24.0/goofys -O /usr/bin/goofys
+RUN wget -q https://github.com/kahing/goofys/releases/download/v0.24.0/goofys -O /usr/bin/goofys
 RUN chmod +x /usr/bin/goofys
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
+RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip -q awscliv2.zip
 RUN ./aws/install
 
 # Prepare action


### PR DESCRIPTION
Use "quiet" options for curl, wget and unzip to not spam the logs with unimportant logs