### PR TITLE
fix: restore s3fs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get -qq update && apt-get -qq install -y \
     bzip2 \
     createrepo \
     unzip \
-    golang \
     s3fs
 
 #RUN wget -q https://github.com/kahing/goofys/releases/download/v0.24.0/goofys -O /usr/bin/goofys

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,24 +5,25 @@ FROM golang:$VERSION
 ARG AWS_S3_MOUNT_DIRECTORY=/mnt/s3
 
 # Tools
-# validate s3fs-fuse with the sec team
 RUN apt-get -qq update && apt-get -qq install -y \
     make \
     curl \
+    wget \
     gnupg2 \
     bzip2 \
     createrepo \
-    unzip
+    unzip \
+    golang \
+    s3fs
+
+#RUN wget -q https://github.com/kahing/goofys/releases/download/v0.24.0/goofys -O /usr/bin/goofys
+#RUN chmod +x /usr/bin/goofys
 
 # Sadly installing aptly with apt lead you to a old version not supporting gpg2
 WORKDIR /tmp
 RUN wget -q https://github.com/aptly-dev/aptly/releases/download/v1.4.0/aptly_1.4.0_linux_amd64.tar.gz
 RUN tar xzf aptly_1.4.0_linux_amd64.tar.gz
 RUN mv ./aptly_1.4.0_linux_amd64/aptly /usr/bin/aptly
-
-
-RUN wget -q https://github.com/kahing/goofys/releases/download/v0.24.0/goofys -O /usr/bin/goofys
-RUN chmod +x /usr/bin/goofys
 
 RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip -q awscliv2.zip
@@ -35,9 +36,11 @@ RUN go build -o /bin/publisher ./publisher.go
 RUN chmod +x /bin/publisher
 
 WORKDIR /home/gha
+RUN mkdir ./assets
+RUN mkdir ./scripts
 ADD schemas ./schemas
 ADD scripts/Makefile .
-RUN mkdir ./assets
+ADD scripts/mount_s3.sh scripts/
 RUN mkdir $AWS_S3_MOUNT_DIRECTORY
 ENV AWS_S3_MOUNT_DIRECTORY $AWS_S3_MOUNT_DIRECTORY
 

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path"
 	"path/filepath"
 	"strings"
@@ -96,7 +97,16 @@ type Upload struct {
 
 type uploadArtifactsSchema []uploadArtifactSchema
 
+// TODO context cancellation
 func main() {
+	// ctrl+c
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func(){
+		<-c
+		os.Exit(1)
+	}()
+
 	conf := loadConfig()
 
 	var bucketLock lock.BucketLock

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -60,19 +60,13 @@ ifeq ($(ENV), release)
 endif
 
 mount-s3:
-	@echo "Assuming IAM role for service account..."
-	$(eval creds := $(shell AWS_PAGER="" aws sts assume-role \
-			--output text \
-			--role-arn $(AWS_ROLE_ARN) \
-			--role-session-name $(AWS_ROLE_SESSION_NAME) \
-		| tail -1 \
-		| awk ' { print "AWS_PAGER=\"\" " \
-						"AWS_REGION=\"$(AWS_REGION)\" " \
-						"AWS_ACCESS_KEY_ID=\"" $$2 "\" " \
-						"AWS_SECRET_ACCESS_KEY=\"" $$4 "\" " \
-						"AWS_SESSION_TOKEN=\"" $$5 "\" "}'))
-	@echo "Mounting S3 bucket $(AWS_S3_BUCKET_NAME) into $(AWS_S3_MOUNT_DIRECTORY)..."
-	@$(creds) goofys $(AWS_S3_BUCKET_NAME) $(AWS_S3_MOUNT_DIRECTORY)
+	@AWS_REGION=$(AWS_REGION) \
+		AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
+		AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
+		AWS_ROLE_SESSION_NAME=$(AWS_ROLE_SESSION_NAME) \
+		AWS_ROLE_ARN=$(AWS_ROLE_ARN) \
+		AWS_S3_BUCKET_NAME=$(AWS_S3_BUCKET_NAME) \
+		scripts/mount_s3.sh
 
 mount-s3-check: mount-s3
 	@echo "Confirm s3 mount..."

--- a/scripts/mount_s3.sh
+++ b/scripts/mount_s3.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# validate inputs
+if [ "$AWS_ACCESS_KEY_ID" = "" ]; then
+  echo "missing AWS_ACCESS_KEY_ID"
+  exit 1
+fi
+if [ "$AWS_SECRET_ACCESS_KEY" = "" ]; then
+  echo "missing AWS_SECRET_ACCESS_KEY"
+  exit 1
+fi
+if [ "$AWS_REGION" = "" ]; then
+  echo "missing AWS_REGION"
+  exit 1
+fi
+if [ "$AWS_REGION" = "" ]; then
+  echo "missing AWS_REGION"
+  exit 1
+fi
+if [ "$AWS_ROLE_SESSION_NAME" = "" ]; then
+  echo "missing AWS_ROLE_SESSION_NAME"
+  exit 1
+fi
+if [ "$AWS_ROLE_ARN" = "" ]; then
+  echo "missing AWS_ROLE_ARN"
+  exit 1
+fi
+if [ "$AWS_S3_BUCKET_NAME" = "" ]; then
+  echo "missing AWS_S3_BUCKET_NAME"
+  exit 1
+fi
+if [ "$AWS_S3_MOUNT_DIRECTORY" = "" ]; then
+  echo "missing AWS_S3_MOUNT_DIRECTORY"
+  exit 1
+fi
+
+export AWS_PAGER=""
+
+STS=($(aws sts assume-role \
+		--role-arn "$AWS_ROLE_ARN" \
+		--role-session-name "$AWS_ROLE_SESSION_NAME" \
+		--query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
+		--output text))
+
+# overwrite AWS key pair credentials with STS negotiated ones.
+export AWS_ACCESS_KEY_ID="${STS[0]}"
+export AWS_SECRET_ACCESS_KEY="${STS[1]}"
+export AWS_SESSION_TOKEN="${STS[2]}"
+
+# verify role successfully assumed
+#aws sts get-caller-identity || (echo "cannot assume IAM role"; exit 1)
+checkfile=deleteme.$(date +%d-%m-%Y_%H-%M-%S)
+touch "${checkfile}"
+aws s3 cp "${checkfile}" "s3://${AWS_S3_BUCKET_NAME}/"
+aws s3 ls "s3://${AWS_S3_BUCKET_NAME}/"
+aws s3 rm "s3://${AWS_S3_BUCKET_NAME}/${checkfile}"
+
+# s3fs token issue: https://github.com/s3fs-fuse/s3fs-fuse/issues/651#issuecomment-561111268
+AWSACCESSKEYID="${AWS_ACCESS_KEY_ID}" \
+AWSSECRETACCESSKEY="${AWS_SECRET_ACCESS_KEY}" \
+AWSSESSIONTOKEN="${AWS_SESSION_TOKEN}" \
+s3fs "${AWS_S3_BUCKET_NAME}" "${AWS_S3_MOUNT_DIRECTORY}"


### PR DESCRIPTION
Goofys turned out to not handle credentials properly when bucket has a bucket-policy attached.
S3fs demonstrated to behave more robust (still slower than Goofys though).

Mount logic isolated on shell script so we can properly verify env-vars.

An extra verification on assumed role is down via aws-cli to diagnose if potential mount errors were caused by credentials issue.