### PR TITLE
feat: add schema of integrations bundling nrjmx in windows installer

### DIFF
--- a/schemas/ohi-jmx.yml
+++ b/schemas/ohi-jmx.yml
@@ -15,7 +15,6 @@
       dest: "{dest_prefix}binaries/windows/{arch}/{src}"
   arch:
     - amd64
-    - 386
 
 # Windows installers are .exe and have the '-installer' string in the name for integrations bundling nrjmx.
 - src: "{app_name}-amd64-installer.{version}.exe"
@@ -25,14 +24,6 @@
     - type: file
       override: true
       dest: "{dest_prefix}windows/integrations/{app_name}/{app_name}-amd64-installer.exe"
-
-- src: "{app_name}-386-installer.{version}.exe"
-  uploads:
-    - type: file
-      dest: "{dest_prefix}windows/386/integrations/{app_name}/{src}"
-    - type: file
-      override: true
-      dest: "{dest_prefix}windows/386/integrations/{app_name}/{app_name}-386-installer.exe"
 
 - src: "{app_name}_{version}-1_{arch}.deb"
   arch:

--- a/schemas/ohi-jmx.yml
+++ b/schemas/ohi-jmx.yml
@@ -1,0 +1,74 @@
+---
+- src: "{app_name}_linux_{version}_{arch}.tar.gz"
+  uploads:
+    - type: file
+      dest: "{dest_prefix}binaries/linux/{arch}/{src}"
+  arch:
+    - amd64
+    - 386
+    - arm
+    - arm64
+
+- src: "{app_name}-{arch}.{version}.zip"
+  uploads:
+    - type: file
+      dest: "{dest_prefix}binaries/windows/{arch}/{src}"
+  arch:
+    - amd64
+    - 386
+
+# Windows installers are .exe and have the '-installer' string in the name for integrations bundling nrjmx.
+- src: "{app_name}-amd64-installer.{version}.exe"
+  uploads:
+    - type: file
+      dest: "{dest_prefix}windows/integrations/{app_name}/{src}"
+    - type: file
+      override: true
+      dest: "{dest_prefix}windows/integrations/{app_name}/{app_name}-amd64-installer.exe"
+
+- src: "{app_name}-386-installer.{version}.exe"
+  uploads:
+    - type: file
+      dest: "{dest_prefix}windows/386/integrations/{app_name}/{src}"
+    - type: file
+      override: true
+      dest: "{dest_prefix}windows/386/integrations/{app_name}/{app_name}-386-installer.exe"
+
+- src: "{app_name}_{version}-1_{arch}.deb"
+  arch:
+    - amd64
+  uploads:
+    - type: apt
+      src_repo: "http://download.newrelic.com/infrastructure_agent/linux/apt"
+      dest: "{dest_prefix}linux/apt/"
+      os_version:
+        - focal
+        - bionic
+        - buster
+        - jessie
+        - precise
+        - stretch
+        - trusty
+        - wheezy
+        - xenial
+
+- src: "{app_name}-{version}-1.{arch}.rpm"
+  arch:
+    - x86_64
+  uploads:
+    - type: yum
+      dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
+      os_version:
+        - 5
+        - 6
+        - 7
+        - 8
+
+    - type: zypp
+      dest: "{dest_prefix}linux/zypp/sles/{os_version}/{arch}/"
+      os_version:
+        - 11.4
+        - 12.1
+        - 12.2
+        - 12.3
+        - 12.4


### PR DESCRIPTION
We have refactored the windows intaller of integrations that uses nrjmx to bundle it in the installer. 
These change has involved a renaming and extension type modification. 
The PR adds these schema to be used by these integrations (kafka, cassandra )