### PR TITLE
refactor: replace goto with for

### DIFF
--- a/publisher/lock/s3_lock.go
+++ b/publisher/lock/s3_lock.go
@@ -99,7 +99,7 @@ func (l *S3) Lock() error {
 			l.logF("%s failed, waiting %s", l.conf.Owner, l.conf.RetryBackoff.String())
 			time.Sleep(l.conf.RetryBackoff)
 		} else {
-		break
+			break
 		}
 	}
 

--- a/publisher/lock/s3_lock.go
+++ b/publisher/lock/s3_lock.go
@@ -93,6 +93,9 @@ func (l *S3) Lock() error {
 	for tries := 0; tries < int(l.conf.MaxRetries); tries++ {
 		l.logF("%s attempt %d", l.conf.Owner, tries)
 		if l.isBusyDeletingExpired() {
+			if tries >= int(l.conf.MaxRetries) {
+				break
+			}
 			l.logF("%s failed, waiting %s", l.conf.Owner, l.conf.RetryBackoff.String())
 			time.Sleep(l.conf.RetryBackoff)
 		}

--- a/publisher/lock/s3_lock.go
+++ b/publisher/lock/s3_lock.go
@@ -90,7 +90,7 @@ func NewS3(c S3Config, logfn Logf) (*S3, error) {
 
 // Lock S3 has no compare-and-swap so this is no bulletproof solution, but should be good enough.
 func (l *S3) Lock() error {
-	for tries := 0; int(l.conf.MaxRetries) - tries > 0; tries++ {
+	for tries := 0; tries < int(l.conf.MaxRetries); tries++ {
 		l.logF("%s attempt %d", l.conf.Owner, tries)
 		if l.isBusyDeletingExpired() {
 			l.logF("%s failed, waiting %s", l.conf.Owner, l.conf.RetryBackoff.String())

--- a/publisher/lock/s3_lock.go
+++ b/publisher/lock/s3_lock.go
@@ -90,15 +90,11 @@ func NewS3(c S3Config, logfn Logf) (*S3, error) {
 
 // Lock S3 has no compare-and-swap so this is no bulletproof solution, but should be good enough.
 func (l *S3) Lock() error {
-	var tries uint
-retry:
-	if (l.conf.MaxRetries - tries) > 0 {
-		tries++
+	for tries := 0; int(l.conf.MaxRetries) - tries > 0; tries++ {
 		l.logF("%s attempt %d", l.conf.Owner, tries)
 		if l.isBusyDeletingExpired() {
 			l.logF("%s failed, waiting %s", l.conf.Owner, l.conf.RetryBackoff.String())
 			time.Sleep(l.conf.RetryBackoff)
-			goto retry
 		}
 	}
 

--- a/publisher/lock/s3_lock.go
+++ b/publisher/lock/s3_lock.go
@@ -98,6 +98,8 @@ func (l *S3) Lock() error {
 			}
 			l.logF("%s failed, waiting %s", l.conf.Owner, l.conf.RetryBackoff.String())
 			time.Sleep(l.conf.RetryBackoff)
+		} else {
+		break
 		}
 	}
 

--- a/publisher/lock/s3_lock.go
+++ b/publisher/lock/s3_lock.go
@@ -92,15 +92,11 @@ func NewS3(c S3Config, logfn Logf) (*S3, error) {
 func (l *S3) Lock() error {
 	for tries := 0; tries < int(l.conf.MaxRetries); tries++ {
 		l.logF("%s attempt %d", l.conf.Owner, tries)
-		if l.isBusyDeletingExpired() {
-			if tries >= int(l.conf.MaxRetries) {
-				break
-			}
-			l.logF("%s failed, waiting %s", l.conf.Owner, l.conf.RetryBackoff.String())
-			time.Sleep(l.conf.RetryBackoff)
-		} else {
+		if !l.isBusyDeletingExpired() || tries >= int(l.conf.MaxRetries) {
 			break
 		}
+		l.logF("%s failed, waiting %s", l.conf.Owner, l.conf.RetryBackoff.String())
+		time.Sleep(l.conf.RetryBackoff)
 	}
 
 	if l.isBusyDeletingExpired() {


### PR DESCRIPTION
Replace goto with for as requested https://github.com/newrelic/infrastructure-publish-action/pull/83#discussion_r607671794

I still think this is one of the few legit usages of goto, making the code more readable in this case.

wdyt?