### PR TITLE
feat: add app_version parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ A GitHub Action to publish artifacts from GitHub release assets into an S3 bucke
 | `repo_name`                | Github repository name, combination of organization and repository. |
 | `app_name`                 | Name of the package. |
 | `tag`                      | Tag version from GitHub release. |
+| `app_version`              | Version of the package. If not present is extracted from the tag removing trailing v (i.e tag=v1.0.1 -> version=1.0.1) |
 | `schema`                   | Describes the packages to be published: infra-agent, ohi, or nrjmx. |
 | `schema_url`               | Url to custom schema file. |
 | `gpg_passphrase`           | Passphrase for the gpg key. |
 | `gpg_private_key_base64`   | Encoded gpg key. |
 | `access_point_host`        | Host url to be used in apt repo mirror & .repo files template. It accepts a url or fixed values <code>production &#124; staging &#124; testing </code> for default urls.<br/><br/>`staging` : http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com <br/> `testing`: http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com <br/> `production`: https://nr-downloads-main.s3.amazonaws.com |
 
-All keys are required.
 
 ## Use Publish Tag
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A GitHub Action to publish artifacts from GitHub release assets into an S3 bucke
 | `repo_name`                | Github repository name, combination of organization and repository. |
 | `app_name`                 | Name of the package. |
 | `tag`                      | Tag version from GitHub release. |
-| `app_version`              | Version of the package. If not present is extracted from the tag removing trailing v (i.e tag=v1.0.1 -> version=1.0.1) |
+| `app_version`              | Version of the package. If not present is extracted from the tag removing the leading v (e.g. tag=v1.0.1 -> version=1.0.1) |
 | `schema`                   | Describes the packages to be published: infra-agent, ohi, or nrjmx. |
 | `schema_url`               | Url to custom schema file. |
 | `gpg_passphrase`           | Passphrase for the gpg key. |

--- a/action-run.sh
+++ b/action-run.sh
@@ -21,6 +21,7 @@ docker run --rm \
         -e AWS_S3_LOCK_BUCKET_NAME \
         -e REPO_NAME \
         -e APP_NAME \
+        -e APP_VERSION \
         -e TAG \
         -e ACCESS_POINT_HOST \
         -e RUN_ID \

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ inputs:
   app_name:
     description: Name of the package (i.e. nri-redis)
     required: true
+  app_version:
+    description: Version of the package. If not present is extracted from the tag removing trailing v (i.e tag=v1.0.1 -> version=1.0.1)
+    required: false
   tag:
     description: Tag pointing to the release
     required: true
@@ -70,6 +73,7 @@ runs:
         GPG_PRIVATE_KEY_BASE64: ${{ inputs.gpg_private_key_base64}}
         REPO_NAME: ${{ inputs.repo_name }}
         APP_NAME: ${{ inputs.app_name }}
+        APP_VERSION: ${{ inputs.app_version }}
         TAG: ${{ inputs.tag }}
         ACCESS_POINT_HOST: ${{ inputs.access_point_host }}
         SCHEMA: ${{ inputs.schema }}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -203,6 +203,7 @@ func loadConfig() config {
 	// TODO: make all the config required
 	viper.BindEnv("repo_name")
 	viper.BindEnv("app_name")
+	viper.BindEnv("app_version")
 	viper.BindEnv("tag")
 	viper.BindEnv("access_point_host")
 	viper.BindEnv("run_id")
@@ -219,6 +220,7 @@ func loadConfig() config {
 	viper.BindEnv("aws_region")
 	viper.BindEnv("disable_lock")
 	viper.BindEnv("lock_retries")
+	viper.BindEnv("lock_group")
 
 	aptlyF := viper.GetString("aptly_folder")
 	if aptlyF == "" {
@@ -228,6 +230,11 @@ func loadConfig() config {
 	lockGroup := viper.GetString("lock_group")
 	if lockGroup == "" {
 		lockGroup = defaultLockgroup
+	}
+
+	version := viper.GetString("app_version")
+	if version == "" {
+		version = strings.Replace(viper.GetString("tag"), "v", "", -1)
 	}
 
 	accessPointHost, mirrorHost := parseAccessPointHost(viper.GetString("access_point_host"))
@@ -240,7 +247,7 @@ func loadConfig() config {
 		mirrorHost:           mirrorHost,
 		accessPointHost:      accessPointHost,
 		runID:                viper.GetString("run_id"),
-		version:              strings.Replace(viper.GetString("tag"), "v", "", -1),
+		version:              version,
 		artifactsDestFolder:  viper.GetString("artifacts_dest_folder"),
 		artifactsSrcFolder:   viper.GetString("artifacts_src_folder"),
 		aptlyFolder:          aptlyF,

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -494,3 +494,55 @@ func expectedLog(prefix, content string) string {
 func reader(content string) io.ReadCloser {
 	return ioutil.NopCloser(bytes.NewReader([]byte(content)))
 }
+
+func Test_loadConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want config
+	}{
+		{
+			name: "defaults are applied",
+			env: map[string]string{
+				"TAG": "vFooBar",
+			},
+			want: config{
+				tag:               "vFooBar",
+				version:           "FooBar",
+				accessPointHost:   accessPointProduction,
+				mirrorHost:        mirrorProduction,
+				aptlyFolder:       defaultAptlyFolder,
+				lockGroup:         defaultLockgroup,
+				useDefLockRetries: true,
+			},
+		},
+		{
+			name: "custom values",
+			env: map[string]string{
+				"TAG":               "vFooBar",
+				"APP_VERSION":       "Baz",
+				"APTLY_FOLDER":      "FooFolder",
+				"LOCK_GROUP":        "FooGroup",
+				"ACCESS_POINT_HOST": "FooAPH",
+				"LOCK_RETRIES":      "false",
+			},
+			want: config{
+				tag:               "vFooBar",
+				version:           "Baz",
+				accessPointHost:   "FooAPH",
+				mirrorHost:        "FooAPH",
+				aptlyFolder:       "FooFolder",
+				lockGroup:         "FooGroup",
+				useDefLockRetries: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				os.Setenv(k, v)
+			}
+			assert.Equal(t, tt.want, loadConfig(), "Case failed:", tt.name, tt.env)
+		})
+	}
+}


### PR DESCRIPTION
Currently the `{version}` from the `tag` parameter (removing the trailing v ) which works when the `tag` only contains version.

This PR adds an optional parameter to the publish action called `app_version` which if existed will be used as the `{version}`, if not, the same behavior remains.

FIX: This PR also introduces a Fix for the `lock_group` which was not being set from Environment variables