### PR TITLE
feat: separate Amazon Linux 2 repository for integrations

### DIFF
--- a/schemas/nrjmx.yml
+++ b/schemas/nrjmx.yml
@@ -61,3 +61,8 @@
         - 12.2
         - 12.3
         - 12.4
+
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2

--- a/schemas/ohi-jmx.yml
+++ b/schemas/ohi-jmx.yml
@@ -67,3 +67,8 @@
         - 12.2
         - 12.3
         - 12.4
+
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2

--- a/schemas/ohi.yml
+++ b/schemas/ohi.yml
@@ -75,3 +75,8 @@
         - 12.2
         - 12.3
         - 12.4
+
+    - type: yum
+     dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+     os_version:
+       - 2


### PR DESCRIPTION
Change integrations Amazon Linux 2 repository as infrastructure-agent repository location for Amazon Linux 2 is going to be changed.