### PR TITLE
Assert error doesn't get overwritten and is returned when one arch fails to get published

### DIFF
--- a/publisher/upload/upload_test.go
+++ b/publisher/upload/upload_test.go
@@ -190,6 +190,51 @@ func TestUploadArtifacts_cantBeRunInParallel(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestUploadArtifacts_errorsIfAnyArchFails(t *testing.T) {
+	schema := []config.UploadArtifactSchema{
+		{"{app_name}-{arch}-{version}.txt", []string{"amd64"}, []config.Upload{
+			{
+				Type: "file",
+				Dest: "{arch}/{app_name}/{src}",
+			},
+		}},
+		{"{app_name}-{arch}-{version}.txt", []string{"amd64", "386"}, []config.Upload{
+			{
+				Type: "file",
+				Dest: "{arch}/{app_name}/{src}",
+			},
+		}},
+	}
+
+	dest := os.TempDir()
+	src := os.TempDir()
+	cfg := config.Config{
+		Version:              "2.0.0",
+		ArtifactsDestFolder:  dest,
+		ArtifactsSrcFolder:   src,
+		UploadSchemaFilePath: "",
+		AppName:              "nri-foobar",
+	}
+
+	err := writeDummyFile(path.Join(src, "nri-foobar-amd64-2.0.0.txt"))
+	assert.NoError(t, err)
+
+	ready := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var err1 error
+	l := lock.NewInMemory()
+	go func() {
+		<-ready
+		err1 = UploadArtifacts(cfg, schema, l)
+		wg.Done()
+	}()
+
+	close(ready)
+	wg.Wait()
+	assert.Error(t, err1)
+}
+
 func Test_generateAptSrcRepoUrl(t *testing.T) {
 	template := "{access_point_host}/infrastructure_agent/linux/apt"
 	accessPointHost := "https://download.newrelic.com"


### PR DESCRIPTION
- Return error when one arch fails directly. The error was getting overwritten if there were more archs to compute and suceeded.