### PR TITLE
sync integration schemas with infra agent

### DIFF
--- a/schemas/nrjmx.yml
+++ b/schemas/nrjmx.yml
@@ -46,11 +46,11 @@
         - hirsute
         - bullseye
 
+# The agent uploads a different versions of packages for x86_64.
+# https://github.com/newrelic/infrastructure-agent/blob/master/build/upload-schema-linux-rpm.yml
 - src: "{app_name}-{version}-1.noarch.rpm"
   arch:
     - x86_64
-    - arm
-    - arm64
   uploads:
     - type: yum
       dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
@@ -76,3 +76,32 @@
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
       os_version:
         - 2
+        - 2022
+
+- src: "{app_name}-{version}-1.noarch.rpm"
+  arch:
+    - arm
+    - arm64
+  uploads:
+    - type: yum
+      dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
+      os_version:
+        - 7
+        - 8
+
+    - type: zypp
+      dest: "{dest_prefix}linux/zypp/sles/{os_version}/{arch}/"
+      os_version:
+        - 12.2
+        - 12.3
+        - 12.4
+        - 12.5
+        - 15.1
+        - 15.2
+        - 15.3
+
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2
+        - 2022

--- a/schemas/ohi-jmx.yml
+++ b/schemas/ohi-jmx.yml
@@ -48,16 +48,15 @@
         - hirsute
         - bullseye
 
+# The agent uploads a different versions of packages for x86_64.
+# https://github.com/newrelic/infrastructure-agent/blob/master/build/upload-schema-linux-rpm.yml
 - src: "{app_name}-{version}-1.{arch}.rpm"
   arch:
     - x86_64
-    - arm
-    - arm64
   uploads:
     - type: yum
       dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
       os_version:
-        - 5
         - 6
         - 7
         - 8
@@ -79,3 +78,32 @@
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
       os_version:
         - 2
+        - 2022
+
+- src: "{app_name}-{version}-1.{arch}.rpm"
+  arch:
+    - arm
+    - arm64
+  uploads:
+    - type: yum
+      dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
+      os_version:
+        - 7
+        - 8
+
+    - type: zypp
+      dest: "{dest_prefix}linux/zypp/sles/{os_version}/{arch}/"
+      os_version:
+        - 12.2
+        - 12.3
+        - 12.4
+        - 12.5
+        - 15.1
+        - 15.2
+        - 15.3
+
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2
+        - 2022

--- a/schemas/ohi.yml
+++ b/schemas/ohi.yml
@@ -56,16 +56,15 @@
         - hirsute
         - bullseye
 
+# The agent uploads a different versions of packages for x86_64.
+# https://github.com/newrelic/infrastructure-agent/blob/master/build/upload-schema-linux-rpm.yml
 - src: "{app_name}-{version}-1.{arch}.rpm"
   arch:
     - x86_64
-    - arm
-    - arm64
   uploads:
     - type: yum
       dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
       os_version:
-        - 5
         - 6
         - 7
         - 8
@@ -87,3 +86,32 @@
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
       os_version:
         - 2
+        - 2022
+
+- src: "{app_name}-{version}-1.{arch}.rpm"
+  arch:
+    - arm
+    - arm64
+  uploads:
+    - type: yum
+      dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
+      os_version:
+        - 7
+        - 8
+
+    - type: zypp
+      dest: "{dest_prefix}linux/zypp/sles/{os_version}/{arch}/"
+      os_version:
+        - 12.2
+        - 12.3
+        - 12.4
+        - 12.5
+        - 15.1
+        - 15.2
+        - 15.3
+
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2
+        - 2022


### PR DESCRIPTION
Splits the rpm upload schema as the [Infra Agent](https://github.com/newrelic/infrastructure-agent/blob/f9f197ab5bfd24c8d5c2781ee3c1c2f7883b99f9/build/upload-schema-linux-rpm.yml) is doing in order to match the supported versions between integrations and the Agent.
