### PR TITLE
Add custom-local schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A GitHub Action to publish artifacts from GitHub release assets into an S3 bucke
 | `app_version`              | Version of the package. If not present is extracted from the tag removing the leading v (e.g. tag=v1.0.1 -> version=1.0.1) |
 | `schema`                   | Describes the packages to be published: infra-agent, ohi, or nrjmx. |
 | `schema_url`               | Url to custom schema file. |
+| `schema_path`              | Path to custom schema file. |
 | `gpg_passphrase`           | Passphrase for the gpg key. |
 | `gpg_private_key_base64`   | Encoded gpg key. |
 | `access_point_host`        | Host url to be used in apt repo mirror & .repo files template. It accepts a url or fixed values <code>production &#124; staging &#124; testing </code> for default urls.<br/><br/>`staging` : http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com <br/> `testing`: http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com <br/> `production`: https://nr-downloads-main.s3.amazonaws.com |
@@ -81,8 +82,12 @@ jobs:
           app_name: "newrelic-infra"
           repo_name: "newrelic/infrastructure-agent"
           env: release
+          # Set the schema from an external server/repo
           schema: "custom"
           schema_url: "https://raw.githubusercontent.com/newrelic/infrastructure-agent/master/build/upload-schema-linux.yml"
+          # Set the schema from this branch
+          #schema: "custom-local"
+          #schema_url: "./build/upload-schema-linux.yml"
           aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}

--- a/action-run.sh
+++ b/action-run.sh
@@ -3,15 +3,16 @@ set -e
 # build docker image form Dockerfile
 echo "Build fresh docker image for newrelic/infrastructure-publish-action"
 # @TODO add --no-cache
-docker build  -t newrelic/infrastructure-publish-action -f $GITHUB_ACTION_PATH/Dockerfile $GITHUB_ACTION_PATH
+docker build --platform linux/amd64 -t newrelic/infrastructure-publish-action -f $GITHUB_ACTION_PATH/Dockerfile $GITHUB_ACTION_PATH
 
-
-# avoid container network errors in GHA runners
-set +e
-echo "Creating iptables rule to drop invalid packages"
-sudo iptables -D INPUT -i eth0 -m state --state INVALID -j DROP 2>/dev/null
-sudo iptables -A INPUT -i eth0 -m state --state INVALID -j DROP
-set -e
+if [ "${CI}" = "true" ]; then
+  # avoid container network errors in GHA runners
+  set +e
+  echo "Creating iptables rule to drop invalid packages"
+  sudo iptables -D INPUT -i eth0 -m state --state INVALID -j DROP 2>/dev/null
+  sudo iptables -A INPUT -i eth0 -m state --state INVALID -j DROP
+  set -e
+fi
 
 # run docker container to perform all actions inside.
 # $( pwd ) is mounted on /srv to enable grabbing packages
@@ -19,7 +20,7 @@ set -e
 # and therefore as LOCAL_PACKAGES_PATH will refer to path
 # inside the docker container it should be `/srv/*`
 echo "Run docker container with action logic inside"
-docker run --rm \
+docker run --platform linux/amd64 --rm \
         --name=infrastructure-publish-action\
         --security-opt apparmor:unconfined \
         --device /dev/fuse \
@@ -42,6 +43,7 @@ docker run --rm \
         -e ARTIFACTS_SRC_FOLDER=/home/gha/assets \
         -e SCHEMA \
         -e SCHEMA_URL \
+        -e SCHEMA_PATH=$( realpath --canonicalize-missing "$SCHEMA_PATH" | sed -e "s|$PWD|/srv|" ) \
         -e GPG_PRIVATE_KEY_BASE64 \
         -e GPG_PASSPHRASE \
         -e DISABLE_LOCK \
@@ -49,4 +51,5 @@ docker run --rm \
         -e DEST_PREFIX \
         -e LOCAL_PACKAGES_PATH \
         -e APT_SKIP_MIRROR \
-        newrelic/infrastructure-publish-action
+        newrelic/infrastructure-publish-action \
+        "$@"

--- a/action.yml
+++ b/action.yml
@@ -49,10 +49,13 @@ inputs:
     description: Http host to use and AP for .repo files in YUM/ZYPP repos
     required: false
   schema:
-    description: Name of the schema describing the packages to be published (i.e. infra-agent, ohi, nrjmx, custom - requires schemaUrl)
+    description: Name of the schema describing the packages to be published (i.e. infra-agent, ohi, nrjmx, custom - requires schema_url, custom-local - requires schema_path)
     required: true
   schema_url:
     description: Url to custom schema file
+    required: false
+  schema_path:
+    description: Path to custom schema file
     required: false
   gpg_passphrase:
     description: Passphrase for the gpg key
@@ -88,6 +91,7 @@ runs:
         ACCESS_POINT_HOST: ${{ inputs.access_point_host }}
         SCHEMA: ${{ inputs.schema }}
         SCHEMA_URL: ${{ inputs.schema_url }}
+        SCHEMA_PATH: ${{ inputs.schema_path }}
         RUN_ID: ${{ inputs.run_id }}
         AWS_S3_LOCK_BUCKET_NAME: ${{ inputs.aws_s3_lock_bucket_name }}
         AWS_REGION: ${{ inputs.aws_region }}

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -40,11 +40,19 @@ ifeq ($(SCHEMA), custom)
 	@echo "Downloaded schema:"
 	@cat ${UPLOAD_SCHEMA_FILE_PATH}
 else
-	@if [[ ! -e "$(WORKDIR)/schemas/$(SCHEMA).yml" ]]; then \
+ifeq ($(SCHEMA), custom-local)
+	@if [[ ! -f "$(SCHEMA_PATH)" ]]; then \
+		echo "Cannot find \"$(SCHEMA_PATH)\""; \
+		exit 1; \
+	fi
+	$(eval UPLOAD_SCHEMA_FILE_PATH := "$(SCHEMA_PATH)")
+else
+	@if [[ ! -f "$(WORKDIR)/schemas/$(SCHEMA).yml" ]]; then \
 		echo "Cannot find $(SCHEMA).yml file in $(WORKDIR)/schemas/"; \
 		exit 1; \
 	fi
 	$(eval UPLOAD_SCHEMA_FILE_PATH := "$(WORKDIR)/schemas/$(SCHEMA).yml")
+endif
 endif
 
 mount-s3:


### PR DESCRIPTION
We have a monorepo where the upload schema can change from one integration to another so we generate the upload schema per integration on each release using a template.

This action only supports setting the schema using a URL, so I added the possibility of adding the schema using a path.

I also changed a few aspects of the script:
 * `iptables` rules are only set if you are running inside the CI
 * Added a `"$@"` at the end of the script to allow local/PR testing. It is not populated in the `action.yml` so there is no possiblity of us abusing it in the pipelines.
 * Allow to run the action script in our new M1s locally. `publisher.go` refused so compile in an ARM processor:
```
 => CACHED [13/23] WORKDIR /home/gha/publisher                                                                       0.0s
 => CACHED [14/23] ADD publisher .                                                                                   0.0s
 => ERROR [15/23] RUN go build -o /bin/publisher ./publisher.go                                                      0.1s
------
 > [15/23] RUN go build -o /bin/publisher ./publisher.go:
#20 0.134 qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
```
 * Action's `Makefile` now test that the schema is a file, a regular file, not a folder.

I tested as much as possible and as many use cases as I could think of. I set all the variables so `make` do not complain about a variable not set but only the ones about the schema are important:

## Testing with `SCHEMA` set to `test`.

```
AWS_REGION=test AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_ROLE_SESSION_NAME=test AWS_ROLE_ARN=test AWS_S3_BUCKET_NAME=test AWS_S3_LOCK_BUCKET_NAME=test REPO_NAME=test APP_NAME=test APP_VERSION=test TAG=test ACCESS_POINT_HOST=test RUN_ID=test ARTIFACTS_DEST_FOLDER=test ARTIFACTS_SRC_FOLDER=test \
GPG_PRIVATE_KEY_BASE64=test GPG_PASSPHRASE=test DISABLE_LOCK=test GPG_KEY_RING=test DEST_PREFIX=test LOCAL_PACKAGES_PATH=test APT_SKIP_MIRROR=test \
GITHUB_ACTION_PATH=$PWD \
SCHEMA=test \
SCHEMA_URL=test \
SCHEMA_PATH=test \
./action-run.sh \
make prepare-schema
```
Result: 
> ```
> Prepare schema file for: test
> Cannot find test.yml file in /home/gha/schemas/
> make: *** [Makefile:37: prepare-schema] Error 1
> ```

## Testing with `SCHEMA` set to `custom-local`.

```
AWS_REGION=test AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_ROLE_SESSION_NAME=test AWS_ROLE_ARN=test AWS_S3_BUCKET_NAME=test AWS_S3_LOCK_BUCKET_NAME=test REPO_NAME=test APP_NAME=test APP_VERSION=test TAG=test ACCESS_POINT_HOST=test RUN_ID=test ARTIFACTS_DEST_FOLDER=test ARTIFACTS_SRC_FOLDER=test \
GPG_PRIVATE_KEY_BASE64=test GPG_PASSPHRASE=test DISABLE_LOCK=test GPG_KEY_RING=test DEST_PREFIX=test LOCAL_PACKAGES_PATH=test APT_SKIP_MIRROR=test \
GITHUB_ACTION_PATH=$PWD \
SCHEMA=custom-local \
SCHEMA_URL=test \
SCHEMA_PATH=test \
./action-run.sh \
make prepare-schema
```
Result: 
> ```
> Prepare schema file for: custom-local
> Cannot find "/srv/test"
> ```

## Testing with `SCHEMA` set to `custom-local`, `SCHEMA_PATH` to `test.yaml` creating the file previously.

```
touch test.yaml

AWS_REGION=test AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_ROLE_SESSION_NAME=test AWS_ROLE_ARN=test AWS_S3_BUCKET_NAME=test AWS_S3_LOCK_BUCKET_NAME=test REPO_NAME=test APP_NAME=test APP_VERSION=test TAG=test ACCESS_POINT_HOST=test RUN_ID=test ARTIFACTS_DEST_FOLDER=test ARTIFACTS_SRC_FOLDER=test \
GPG_PRIVATE_KEY_BASE64=test GPG_PASSPHRASE=test DISABLE_LOCK=test GPG_KEY_RING=test DEST_PREFIX=test LOCAL_PACKAGES_PATH=test APT_SKIP_MIRROR=test \
GITHUB_ACTION_PATH=$PWD \
SCHEMA=custom-local \
SCHEMA_URL=test \
SCHEMA_PATH=test \
./action-run.sh \
make prepare-schema
```
Result: 
> ```
> Prepare schema file for: custom-local
> ```

If I run after that `echo $?` it prints `0`.