### PR TITLE
Make e2e test more reliable

### DIFF
--- a/test/publish-agent.sh
+++ b/test/publish-agent.sh
@@ -93,6 +93,7 @@ AWS_S3_LOCK_BUCKET_NAME="$AWS_S3_LOCK_BUCKET_NAME" \
 AWS_ROLE_SESSION_NAME="$AWS_ROLE_SESSION_NAME" \
 AWS_ROLE_ARN="$AWS_ROLE_ARN" \
 DEST_PREFIX="$DEST_PREFIX" \
+CI="${CI:-false}" \
 "${ROOT_DIR}/action-run.sh"
 
 printf "\n * Action run finished.\n"


### PR DESCRIPTION
In the last PR (#142) I modified the script to only apply `iptables` rules inside the CI so we can run the action locally to test things.

I did not modify the e2e script that calls the script explicitly so the e2e is unreliable and it failed the last CI run.

This should fix the issue.