### PR TITLE
Deleting unused software from githubRunner to free up space

### DIFF
--- a/action-run.sh
+++ b/action-run.sh
@@ -16,10 +16,12 @@ fi
 
 ## Freeing space since 14GB are not enough anymore
 df -ih
+df -h
 if [ "${CI}" = "true" ]; then
   echo "Deleting android, dotnet, haskell, CodeQL, Python, swift to free up space"
   sudo rm -rf /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Python /usr/share/swift
   df -ih
+  df -h
 fi
 
 
@@ -66,3 +68,4 @@ docker run --platform linux/amd64 --rm \
 # Verifying how much space is still available
 echo "After running the upload command this is the current status"
 df -ih
+df -h

--- a/action-run.sh
+++ b/action-run.sh
@@ -15,10 +15,13 @@ if [ "${CI}" = "true" ]; then
 fi
 
 ## Freeing space since 14GB are not enough anymore
-df -h
-echo "Deleting android, dotnet, haskell, CodeQL, Python, swift to free up space"
-sudo rm -rf /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Python /usr/share/swift
-df -h
+if [ "${CI}" = "true" ]; then
+  df -ih
+  echo "Deleting android, dotnet, haskell, CodeQL, Python, swift to free up space"
+  sudo rm -rf /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Python /usr/share/swift
+  df -ih
+fi
+
 
 # run docker container to perform all actions inside.
 # $( pwd ) is mounted on /srv to enable grabbing packages
@@ -62,4 +65,4 @@ docker run --platform linux/amd64 --rm \
 
 # Verifying how much space is still available
 echo "After running the upload command this is the current status"
-df -h
+df -ih

--- a/action-run.sh
+++ b/action-run.sh
@@ -15,8 +15,8 @@ if [ "${CI}" = "true" ]; then
 fi
 
 ## Freeing space since 14GB are not enough anymore
+df -ih
 if [ "${CI}" = "true" ]; then
-  df -ih
   echo "Deleting android, dotnet, haskell, CodeQL, Python, swift to free up space"
   sudo rm -rf /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Python /usr/share/swift
   df -ih

--- a/action-run.sh
+++ b/action-run.sh
@@ -14,6 +14,12 @@ if [ "${CI}" = "true" ]; then
   set -e
 fi
 
+## Freeing space since 14GB are not enough anymore
+df -h
+echo "Deleting android, dotnet, haskell, CodeQL, Python, swift to free up space"
+sudo rm -rf /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Python /usr/share/swift
+df -h
+
 # run docker container to perform all actions inside.
 # $( pwd ) is mounted on /srv to enable grabbing packages
 # from the host machine instead of downloading them from GH,
@@ -53,3 +59,7 @@ docker run --platform linux/amd64 --rm \
         -e APT_SKIP_MIRROR \
         newrelic/infrastructure-publish-action \
         "$@"
+
+# Verifying how much space is still available
+echo "After running the upload command this is the current status"
+df -h


### PR DESCRIPTION
Deleting some unused software frees up 25GB allowing us to buy some time in order to understand how quickly we should fix the issue.

Notice that it is a workaround proposed by some GitHub runners maintainers in a couple of issues

![image](https://github.com/newrelic/infrastructure-publish-action/assets/43335750/9f8a4b41-1c52-458d-8ff8-4162c745fde2)
