### PR TITLE
add fips upload schemas to ohi.yml

### DIFF
--- a/schemas/ohi-fips.yml
+++ b/schemas/ohi-fips.yml
@@ -5,38 +5,11 @@
       dest: "{dest_prefix}binaries/linux/{arch}/{src}"
   arch:
     - amd64
-    - 386
-    - arm
     - arm64
-
-- src: "{app_name}-{arch}.{version}.zip"
-  uploads:
-    - type: file
-      dest: "{dest_prefix}binaries/windows/{arch}/{src}"
-  arch:
-    - amd64
-    - 386
-
-- src: "{app_name}-amd64.{version}.msi"
-  uploads:
-    - type: file
-      dest: "{dest_prefix}windows/integrations/{app_name}/{src}"
-    - type: file
-      override: true
-      dest: "{dest_prefix}windows/integrations/{app_name}/{app_name}-amd64.msi"
-
-- src: "{app_name}-386.{version}.msi"
-  uploads:
-    - type: file
-      dest: "{dest_prefix}windows/386/integrations/{app_name}/{src}"
-    - type: file
-      override: true
-      dest: "{dest_prefix}windows/386/integrations/{app_name}/{app_name}-386.msi"
 
 - src: "{app_name}_{version}-1_{arch}.deb"
   arch:
     - amd64
-    - arm
     - arm64
   uploads:
     - type: apt
@@ -62,7 +35,6 @@
 - src: "{app_name}-{version}-1.{arch}.rpm"
   arch:
     - x86_64
-    - arm
     - arm64
   uploads:
     - type: yum

--- a/schemas/ohi.yml
+++ b/schemas/ohi.yml
@@ -9,6 +9,14 @@
     - arm
     - arm64
 
+- src: "{app_name}_linux_{version}_{arch}_fips.tar.gz"
+  uploads:
+    - type: file
+      dest: "{dest_prefix}binaries/linux/{arch}/{src}"
+  arch:
+    - amd64
+    - arm64
+
 - src: "{app_name}-{arch}.{version}.zip"
   uploads:
     - type: file
@@ -59,10 +67,70 @@
         - bullseye
         - bookworm
 
+- src: "{app_name}_{version}-1_{arch}_fips.deb"
+  arch:
+    - amd64
+    - arm64
+  uploads:
+    - type: apt
+      src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
+      dest: "{dest_prefix}linux/apt/"
+      os_version:
+        - noble
+        - jammy
+        - focal
+        - bionic
+        - buster
+        - jessie
+        - precise
+        - stretch
+        - trusty
+        - wheezy
+        - xenial
+        - groovy
+        - hirsute
+        - bullseye
+        - bookworm
+
 - src: "{app_name}-{version}-1.{arch}.rpm"
   arch:
     - x86_64
     - arm
+    - arm64
+  uploads:
+    - type: yum
+      dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
+      os_version:
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+
+    - type: zypp
+      dest: "{dest_prefix}linux/zypp/sles/{os_version}/{arch}/"
+      os_version:
+        - 11.4
+        - 12.1
+        - 12.2
+        - 12.3
+        - 12.4
+        - 12.5
+        - 15.1
+        - 15.2
+        - 15.3
+        - 15.4
+        - 15.5
+
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2
+        - 2023
+
+- src: "{app_name}-{version}-1.{arch}_fips.rpm"
+  arch:
+    - x86_64
     - arm64
   uploads:
     - type: yum


### PR DESCRIPTION
We need to publish FIPS packages in addition to the existing packages. Therefore, update the schema for s3 upload.

[S3 after prerelease run with this schema for nri-redis](http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/rohan-fips-test-redis/)

***Note:*** ~This is a breaking change until all OHIs are updated to have FIPS packages.~