### PR TITLE
feat(fips): add ohi jmx fips schema

### DIFF
--- a/schemas/ohi-jmx-fips.yml
+++ b/schemas/ohi-jmx-fips.yml
@@ -1,0 +1,68 @@
+---
+- src: "{app_name}_linux_{version}_{arch}.tar.gz"
+  uploads:
+    - type: file
+      dest: "{dest_prefix}binaries/linux/{arch}/{src}"
+  arch:
+    - amd64
+    - arm64
+
+- src: "{app_name}_{version}-1_{arch}.deb"
+  arch:
+    - amd64
+    - arm64
+  uploads:
+    - type: apt
+      src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
+      dest: "{dest_prefix}linux/apt/"
+      os_version:
+        - noble
+        - jammy
+        - focal
+        - bionic
+        - buster
+        - jessie
+        - precise
+        - stretch
+        - trusty
+        - wheezy
+        - xenial
+        - groovy
+        - hirsute
+        - bullseye
+        - bookworm
+
+- src: "{app_name}-{version}-1.{arch}.rpm"
+  arch:
+    - x86_64
+    - arm64
+  uploads:
+    - type: yum
+      dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
+      os_version:
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+
+    - type: zypp
+      dest: "{dest_prefix}linux/zypp/sles/{os_version}/{arch}/"
+      os_version:
+        - 11.4
+        - 12.1
+        - 12.2
+        - 12.3
+        - 12.4
+        - 12.5
+        - 15.1
+        - 15.2
+        - 15.3
+        - 15.4
+        - 15.5
+
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2
+        - 2023


### PR DESCRIPTION
It is almost the same as `ohi-jmx` schema, but with support only for linux amd64 and linux arm64.