### PR TITLE
feat: retry if deb mirror update fails

### DIFF
--- a/publisher/upload/upload.go
+++ b/publisher/upload/upload.go
@@ -346,9 +346,10 @@ func mirrorAPTRepo(conf config.Config, repoUrl string, osVersion string) (err er
 	utils.Logger.Printf("[✔] Mirror create succesfully APT repo for %s", osVersion)
 
 	utils.Logger.Printf("[ ] Mirror update APT repo for %s", osVersion)
-	if err = utils.ExecLogOutput(utils.Logger, "aptly", commandTimeout, "mirror", "update", "-max-tries", strconv.Itoa(s3Retries), "-keyring", conf.GpgKeyRing, "mirror-"+osVersion); err != nil {
+	if err = utils.ExecWithRetries(s3Retries, utils.S3RemountFn, utils.Logger, "aptly", commandTimeout, "mirror", "update", "-max-tries", strconv.Itoa(s3Retries), "-keyring", conf.GpgKeyRing, "mirror-"+osVersion); err != nil {
 		return err
 	}
+
 	utils.Logger.Printf("[✔] Mirror update succesfully APT repo for %s", osVersion)
 
 	// The last parameter is `Name` that means a query matches all the packages (as it means “package name is not empty”).


### PR DESCRIPTION
`aptly mirror update` seems to continue failing even if `-max-tries` is present:

<img width="1019" alt="Screenshot 2025-02-10 at 14 37 59" src="https://github.com/user-attachments/assets/f804c634-2fb2-4274-bff4-2cbf67a3fccc" />

<img width="1671" alt="Screenshot 2025-02-10 at 14 38 46" src="https://github.com/user-attachments/assets/d3139ec3-864a-44a4-b66e-a275ec109a97" />

https://github.com/newrelic/nri-mysql/actions/runs/13156763333/job/36715558791

This PR adds retries in shell level as `aptly mirror update` is idempotent 