### PR TITLE
feat: validate app name is consistent with pkg name

### DIFF
--- a/publisher/config/schema_test.go
+++ b/publisher/config/schema_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"log"
 	"testing"
@@ -127,7 +128,8 @@ func TestSchema(t *testing.T) {
 		{"invalid yaml schema", "../../test/schemas/bad-formatted-yaml.yml", errors.New("yaml: line 27: mapping values are not allowed in this context")},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			uploadSchema, err := ParseUploadSchemasFile(tt.schemaPath)
@@ -137,30 +139,7 @@ func TestSchema(t *testing.T) {
 	}
 }
 
-func TestValidateSchemas_UploadType(t *testing.T) {
-	tests := []struct {
-		name          string
-		appName       string
-		schemas       UploadArtifactSchemas
-		expectedError error
-	}{
-		{name: "valid apt", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.deb", Uploads: []Upload{{Type: TypeApt}}}}, expectedError: nil},
-		{name: "valid yum", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.rpm", Uploads: []Upload{{Type: TypeYum}}}}, expectedError: nil},
-		{name: "valid file", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.tar-gz", Uploads: []Upload{{Type: TypeFile}}}}, expectedError: nil},
-		{name: "valid zypp", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.rpm", Uploads: []Upload{{Type: TypeZypp}}}}, expectedError: nil},
-		{name: "invalid type even with valid file", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.deb", Uploads: []Upload{{Type: "something wrong"}}}}, expectedError: errors.New("invalid upload type: something wrong")},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			err := ValidateSchemas(tt.appName, tt.schemas)
-			assert.Equal(t, tt.expectedError, err)
-		})
-	}
-}
-
-func TestValidateSchemas_AppNameShouldBePkgPrefix(t *testing.T) {
+func TestValidateSchemas(t *testing.T) {
 	tests := []struct {
 		name          string
 		appName       string
@@ -169,13 +148,66 @@ func TestValidateSchemas_AppNameShouldBePkgPrefix(t *testing.T) {
 	}{
 		{name: "valid app name with pkg suffix", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_some_suffix_0.0.1_amd64.deb", Uploads: []Upload{{Type: TypeApt}}}}, expectedError: nil},
 		{name: "valid app name exactly as pkg name", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.deb", Uploads: []Upload{{Type: TypeApt}}}}, expectedError: nil},
-		{name: "invalid app name", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-other-name_0.0.1_amd64.deb", Uploads: []Upload{{Type: TypeFile}}}}, expectedError: errors.New("invalid app name: some-app-name")},
+		{name: "invalid app name", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-other-name_0.0.1_amd64.deb", Uploads: []Upload{{Type: TypeFile}}}}, expectedError: ErrInvalidAppName},
+		{name: "valid apt", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.deb", Uploads: []Upload{{Type: TypeApt}}}}, expectedError: nil},
+		{name: "valid yum", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.rpm", Uploads: []Upload{{Type: TypeYum}}}}, expectedError: nil},
+		{name: "valid file", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.tar-gz", Uploads: []Upload{{Type: TypeFile}}}}, expectedError: nil},
+		{name: "valid zypp", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.rpm", Uploads: []Upload{{Type: TypeZypp}}}}, expectedError: nil},
+		{name: "invalid type even with valid file", appName: "some-app-name", schemas: UploadArtifactSchemas{{Src: "some-app-name_0.0.1_amd64.deb", Uploads: []Upload{{Type: "something wrong"}}}}, expectedError: ErrInvalidType},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := ValidateSchemas(tt.appName, tt.schemas)
+			assert.ErrorIs(t, err, tt.expectedError)
+		})
+	}
+}
+
+func Test_ValidTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		uploadType    string
+		expectedError error
+	}{
+		{name: "valid apt", uploadType: TypeApt, expectedError: nil},
+		{name: "valid yum", uploadType: TypeYum, expectedError: nil},
+		{name: "valid file", uploadType: TypeFile, expectedError: nil},
+		{name: "valid zypp", uploadType: TypeZypp, expectedError: nil},
+		{name: "invalid empty", uploadType: "", expectedError: fmt.Errorf("%w: '' (valid types: file, zypp, yum, apt)", ErrInvalidType)},
+		{name: "invalid type", uploadType: "something wrong", expectedError: fmt.Errorf("%w: 'something wrong' (valid types: file, zypp, yum, apt)", ErrInvalidType)},
+	}
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateType(tt.uploadType)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func Test_ValidateName(t *testing.T) {
+	tests := []struct {
+		name          string
+		appName       string
+		src           string
+		expectedError error
+	}{
+		{name: "empty appName is invalid", appName: "", src: "some-app-name_some_suffix_0.0.1_amd64.deb", expectedError: fmt.Errorf("%w: appName cannot be empty", ErrInvalidAppName)},
+		{name: "not matching prefix is invalid", appName: "other-app-name", src: "some-app-name_some_suffix_0.0.1_amd64.deb", expectedError: fmt.Errorf("%w: other-app-name should prefix some-app-name_some_suffix_0.0.1_amd64.deb", ErrInvalidAppName)},
+		{name: "matching prefix is valid", appName: "some-app-name", src: "some-app-name_some_suffix_0.0.1_amd64.deb", expectedError: nil},
+	}
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fmt.Println(tt.appName, tt.src)
+			err := validateName(tt.appName, tt.src)
 			assert.Equal(t, tt.expectedError, err)
 		})
 	}

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -89,6 +89,10 @@ func main() {
 	if err != nil {
 		l.Fatal(err)
 	}
+	// validate schemas
+	if err = config.ValidateSchemas(conf.AppName, uploadSchemas); err != nil {
+		l.Fatal(err)
+	}
 
 	if conf.LocalPackagesPath == "" {
 		d := download.NewDownloader(http.DefaultClient)

--- a/publisher/upload/upload.go
+++ b/publisher/upload/upload.go
@@ -18,11 +18,6 @@ import (
 )
 
 const (
-	//FileTypes
-	typeFile         = "file"
-	typeZypp         = "zypp"
-	typeYum          = "yum"
-	typeApt          = "apt"
 	repodataRpmPath  = "/repodata/repomd.xml"
 	signatureRpmPath = "/repodata/repomd.xml.asc"
 	aptPoolMain      = "pool/main/"
@@ -33,7 +28,7 @@ const (
 )
 
 func uploadArtifact(conf config.Config, schema config.UploadArtifactSchema, upload config.Upload) (err error) {
-	if upload.Type == typeFile {
+	if upload.Type == config.TypeFile {
 		utils.Logger.Println("Uploading file artifact")
 		for _, arch := range schema.Arch {
 			if len(upload.OsVersion) == 0 {
@@ -50,7 +45,7 @@ func uploadArtifact(conf config.Config, schema config.UploadArtifactSchema, uplo
 				}
 			}
 		}
-	} else if upload.Type == typeYum || upload.Type == typeZypp {
+	} else if upload.Type == config.TypeYum || upload.Type == config.TypeZypp {
 		utils.Logger.Println("Uploading rpm as yum or zypp")
 		for _, arch := range schema.Arch {
 			err = uploadRpm(conf, schema.Src, upload, arch)
@@ -58,7 +53,7 @@ func uploadArtifact(conf config.Config, schema config.UploadArtifactSchema, uplo
 				return err
 			}
 		}
-	} else if upload.Type == typeApt {
+	} else if upload.Type == config.TypeApt {
 		utils.Logger.Println("Uploading apt")
 		err = uploadApt(conf, schema.Src, upload, schema.Arch)
 		if err != nil {


### PR DESCRIPTION
`APP_NAME` and artifact name should match or at least the package name should have `APP_NAME` as prefix. 

Explanation:
The action will receive the next parameters, among others:
* src: some-package-name-1.2.3-any.deb
* `APP_NAME`: some-package-name

Based on these parameters, the artifact will be uploaded to:

```
# example for noble

   └── infrastructure_agent
        └── linux
            └── apt
                ├── dists
                │   └── noble
                │       ├── Contents-amd64.gz
                │       ├── InRelease
                │       ├── main
                │       │   ├── binary-amd64
                │       │   │   ├── Packages
                │       │   │   ├── Packages.bz2
                │       │   │   ├── Packages.gz
                │       │   │   └── Release
                │       │   └── Contents-amd64.gz
                │       ├── Release
                │       └── Release.gpg
                └── pool
                    └── main
                        └── s
                            └── some-package-name
                                └── some-package-name-1.2.3-any.deb
```
Where:
*  `s` is retrieved by the first letter of the artifact (`some-package-name-1.2.3-any.deb`)
* folder `some-package-name` is `APP_NAME`
* `some-package-name-1.2.3-any.deb` is the artifact name

And the metadata will contain the path of the file, but it will not use `APP_NAME` for it, it will use the package name provided by the `deb` file, so this can lead to inconsistency between the location of the artifact and the path in the metadata.