### PR TITLE
feat: add retries to GH asset download

### DIFF
--- a/publisher/utils/utils.go
+++ b/publisher/utils/utils.go
@@ -164,3 +164,17 @@ func S3RemountFn(l *log.Logger, commandTimeout time.Duration) {
 		l.Printf("mounting s3 failed %v", err)
 	}
 }
+
+// Retry executes the provided function fn until it succeeds or the maximum number of retries is reached.
+// It waits for the specified delay between each retry.
+func Retry(fn func() error, retries int, delay time.Duration, onErr func()) error {
+	var err error
+	for i := 0; i < retries; i++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		onErr()
+		time.Sleep(delay)
+	}
+	return err
+}


### PR DESCRIPTION
This PR adds retries to GH asset download process. 

The latest release failed because of it:

```
[✔] Download https://github.com/newrelic/infrastructure-agent/releases/download/1.62.0/newrelic-infra-1.62.0-1.sles12.2.arm.rpm.sum into /home/gha/assets/newrelic-infra-1.62.0-1.sles12.2.arm.rpm.sum 107 bytes
Starting downloading artifacts!
[ ] Download https://github.com/newrelic/infrastructure-agent/releases/download/1.62.0/newrelic-infra-1.62.0-1.sles12.3.arm.rpm.sum into /home/gha/assets/newrelic-infra-1.62.0-1.sles12.3.arm.rpm.sum
error on download https://github.com/newrelic/infrastructure-agent/releases/download/1.62.0/newrelic-infra-1.62.0-1.sles12.3.arm.rpm.sum with status code 403
make: *** [Makefile:69: publish-artifacts] Error 1
Error: Process completed with exit code 2.
```