### PR TITLE
Added nrjmx-fips schema

### DIFF
--- a/schemas/nrjmx-fips.yml
+++ b/schemas/nrjmx-fips.yml
@@ -1,0 +1,64 @@
+---
+- src: "{app_name}_linux-fips_{version}_{arch}.tar.gz"
+  uploads:
+    - type: file
+      dest: "{dest_prefix}binaries/linux/{arch}/{src}"
+  arch:
+    - noarch
+
+- src: "{app_name}_{version}-1_{arch}.deb"
+  arch:
+    - noarch
+  uploads:
+    - type: apt
+      src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
+      dest: "{dest_prefix}linux/apt/"
+      os_version:
+        - noble
+        - jammy
+        - focal
+        - bionic
+        - buster
+        - jessie
+        - precise
+        - stretch
+        - trusty
+        - wheezy
+        - xenial
+        - groovy
+        - hirsute
+        - bullseye
+        - bookworm
+
+- src: "{app_name}-{version}-1.{arch}.rpm"
+  arch:
+    - noarch
+  uploads:
+    - type: yum
+      dest: "{dest_prefix}linux/yum/el/{os_version}/{arch}/"
+      os_version:
+        - 6
+        - 7
+        - 8
+        - 9
+
+    - type: zypp
+      dest: "{dest_prefix}linux/zypp/sles/{os_version}/{arch}/"
+      os_version:
+        - 11.4
+        - 12.1
+        - 12.2
+        - 12.3
+        - 12.4
+        - 12.5
+        - 15.1
+        - 15.2
+        - 15.3
+        - 15.4
+        - 15.5
+
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2
+        - 2023


### PR DESCRIPTION
Added FIPS schema for nrjmx.
The filenames to be supported are:
[nrjmx-fips-2.7.1-1.noarch.rpm](https://github.com/newrelic/nrjmx/releases/download/v2.7.1/nrjmx-fips-2.7.1-1.noarch.rpm)
[nrjmx-fips_2.7.1-1_noarch.deb](https://github.com/newrelic/nrjmx/releases/download/v2.7.1/nrjmx-fips_2.7.1-1_noarch.deb)
[nrjmx_linux-fips_2.7.1_noarch.tar.gz](https://github.com/newrelic/nrjmx/releases/download/v2.7.1/nrjmx_linux-fips_2.7.1_noarch.tar.gz)