### PR TITLE
SLES 15.6 support

### DIFF
--- a/schemas/nrjmx.yml
+++ b/schemas/nrjmx.yml
@@ -77,6 +77,7 @@
         - 15.3
         - 15.4
         - 15.5
+        - 15.6
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"

--- a/schemas/ohi-fips.yml
+++ b/schemas/ohi-fips.yml
@@ -60,6 +60,7 @@
         - 15.3
         - 15.4
         - 15.5
+        - 15.6
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"

--- a/schemas/ohi-jmx-fips.yml
+++ b/schemas/ohi-jmx-fips.yml
@@ -60,6 +60,7 @@
         - 15.3
         - 15.4
         - 15.5
+        - 15.6
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"

--- a/schemas/ohi-jmx.yml
+++ b/schemas/ohi-jmx.yml
@@ -80,6 +80,7 @@
         - 15.3
         - 15.4
         - 15.5
+        - 15.6
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"

--- a/schemas/ohi.yml
+++ b/schemas/ohi.yml
@@ -88,6 +88,7 @@
         - 15.3
         - 15.4
         - 15.5
+        - 15.6
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"


### PR DESCRIPTION
Added support for SLES 15.6 to the publish schemas.
Refer to this commit for context on a similar task
https://github.com/newrelic/infrastructure-publish-action/commit/d953e9b5655e28b0def3b1b452e819d0c0b199cb