### PR TITLE
NR-455789 Suse 15.7 OS upgrade

### DIFF
--- a/schemas/nrjmx-fips.yml
+++ b/schemas/nrjmx-fips.yml
@@ -61,6 +61,7 @@
         - 15.4
         - 15.5
         - 15.6
+        - 15.7
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"

--- a/schemas/nrjmx.yml
+++ b/schemas/nrjmx.yml
@@ -77,6 +77,7 @@
         - 15.4
         - 15.5
         - 15.6
+        - 15.7
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"

--- a/schemas/ohi-fips.yml
+++ b/schemas/ohi-fips.yml
@@ -61,6 +61,7 @@
         - 15.4
         - 15.5
         - 15.6
+        - 15.7
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"

--- a/schemas/ohi-jmx-fips.yml
+++ b/schemas/ohi-jmx-fips.yml
@@ -61,6 +61,7 @@
         - 15.4
         - 15.5
         - 15.6
+        - 15.7
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"

--- a/schemas/ohi-jmx.yml
+++ b/schemas/ohi-jmx.yml
@@ -81,6 +81,7 @@
         - 15.4
         - 15.5
         - 15.6
+        - 15.7
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"

--- a/schemas/ohi.yml
+++ b/schemas/ohi.yml
@@ -89,6 +89,7 @@
         - 15.4
         - 15.5
         - 15.6
+        - 15.7
 
     - type: yum
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"


### PR DESCRIPTION
# Add SLES 15.7 Support to Distribution Schemas

## Overview
Adds SUSE Linux Enterprise Server 15.7 support to all New Relic component distribution schemas.

## Changes Made
Added `15.7` to SUSE OS versions in 6 schema files:

- ✅ `schemas/ohi.yml` - On-Host Integrations
- ✅ `schemas/ohi-fips.yml` - On-Host Integrations (FIPS)
- ✅ `schemas/ohi-jmx.yml` - OHI JMX packages
- ✅ `schemas/ohi-jmx-fips.yml` - OHI JMX packages (FIPS)
- ✅ `schemas/nrjmx.yml` - New Relic JMX
- ✅ `schemas/nrjmx-fips.yml` - New Relic JMX (FIPS)

## Impact
- 🆕 SLES 15.7 customers can now install all New Relic monitoring components
- 📦 Packages will be distributed to `linux/zypp/sles/15.7/{arch}/` repositories
- 🔐 Both regular and FIPS-compliant variants supported

## SUSE Support Matrix
```yaml
os_versions: [15.3, 15.4, 15.5, 15.6, 15.7] # 15.7 added