### PR TITLE
feat: add Ubuntu 26.04 (Resolute Raccoon) to OHI publish schema

### DIFF
--- a/schemas/nrjmx-fips.yml
+++ b/schemas/nrjmx-fips.yml
@@ -16,6 +16,7 @@
       src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
       dest: "{dest_prefix}linux/apt/"
       os_version:
+        - resolute
         - noble
         - jammy
         - focal

--- a/schemas/nrjmx.yml
+++ b/schemas/nrjmx.yml
@@ -32,6 +32,7 @@
       src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
       dest: "{dest_prefix}linux/apt/"
       os_version:
+        - resolute
         - noble
         - jammy
         - focal

--- a/schemas/ohi-fips.yml
+++ b/schemas/ohi-fips.yml
@@ -16,6 +16,7 @@
       src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
       dest: "{dest_prefix}linux/apt/"
       os_version:
+        - resolute
         - noble
         - jammy
         - focal

--- a/schemas/ohi-jmx-fips.yml
+++ b/schemas/ohi-jmx-fips.yml
@@ -16,6 +16,7 @@
       src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
       dest: "{dest_prefix}linux/apt/"
       os_version:
+        - resolute
         - noble
         - jammy
         - focal

--- a/schemas/ohi-jmx.yml
+++ b/schemas/ohi-jmx.yml
@@ -35,6 +35,7 @@
       src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
       dest: "{dest_prefix}linux/apt/"
       os_version:
+        - resolute
         - noble
         - jammy
         - focal

--- a/schemas/ohi.yml
+++ b/schemas/ohi.yml
@@ -43,6 +43,7 @@
       src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
       dest: "{dest_prefix}linux/apt/"
       os_version:
+        - resolute
         - noble
         - jammy
         - focal


### PR DESCRIPTION
Adds Ubuntu 26.04 LTS "Resolute Raccoon" (codename: resolute) to the apt os_version list in all OHI publish schemas so that packages are published to the resolute apt repository on the next release.                                                                     
                                                                                                                                                                                                                                                                             
  Files updated:                                                                                                                                                                                                                                                             
  - schemas/ohi.yml                                                                                                                                                                                                                                                          
  - schemas/ohi-jmx.yml                                                                                                                                                                                                                                                      
  - schemas/ohi-fips.yml                                                                                                                                                                                                                                                     
  - schemas/ohi-jmx-fips.yml                                                                                                                                                                                                                                                 
  - schemas/nrjmx.yml                                                                                                                                                                                                                                                        
  - schemas/nrjmx-fips.yml  