### PR TITLE
ci: change github runner version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: Build and publish docker image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ env:
 jobs:
   publishing-to-s3-linux:
     name: Publish linux artifacts into s3 bucket
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Login to DockerHub


### PR DESCRIPTION
Ubuntu 20.04 has been depreciated from github runners